### PR TITLE
indicate that "range" is not supported

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ impl LanguageServer for Backend {
                                     ],
                                     token_modifiers: vec![],
                                 },
-                                range: Some(true),
+                                range: Some(false),
                                 full: Some(SemanticTokensFullOptions::Delta { delta: Some(true) }),
                             },
                             static_registration_options: StaticRegistrationOptions::default(),


### PR DESCRIPTION
Fixes #1 

Assuming I'm correct that this LSP doesn't actually support `textDocument/semanticTokens/range`, this ensures that is reported in the capabilities.

I've tested this locally with my own VS Code extension.